### PR TITLE
Convergent docker image

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,4 +21,5 @@ group :development do
   gem "guard-rake"
   gem "pry"
   gem "yard"
+  gem "vagrant-wrapper"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,6 +332,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.6)
+    vagrant-wrapper (2.0.2)
     websocket (1.2.1)
     yard (0.8.7.6)
 
@@ -355,4 +356,5 @@ DEPENDENCIES
   rspec-puppet!
   travis
   travis-lint
+  vagrant-wrapper
   yard

--- a/files/update_docker_image.sh
+++ b/files/update_docker_image.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Pulls a docker image and returns 0 if there a change.
+# Returns 1 if there is no change.
+DOCKER_IMAGE=$1
+
+BEFORE=$(docker inspect --format='{{.Config.Image}}' ${DOCKER_IMAGE} 2>/dev/null)
+docker pull ${DOCKER_IMAGE}
+AFTER=$(docker inspect --format='{{.Config.Image}}' ${DOCKER_IMAGE} 2>/dev/null)
+
+if [[ $BEFORE == $AFTER ]]; then
+  echo "No updates to ${DOCKER_IMAGE} available"
+  exit 1
+else
+  echo "${DOCKER_IMAGE} updated"
+  exit 0
+fi

--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -56,11 +56,11 @@ define docker::image(
   if $image_tag {
     $image_arg     = "${image}:${image_tag}"
     $image_remove  = "${docker_command} rmi ${image_force}${image}:${image_tag}"
-    $image_find    = "${docker_command} images | grep ^${image} | awk '{ print \$2 }' | grep ^${image_tag}$"
+    $image_find    = "${docker_command} images | egrep '^(docker.io/)?${image} ' | awk '{ print \$2 }' | grep ^${image_tag}$"
   } else {
     $image_arg     = $image
     $image_remove  = "${docker_command} rmi ${image_force}${image}"
-    $image_find    = "${docker_command} images | grep ^${image}"
+    $image_find    = "${docker_command} images | cut -d ' ' -f 1 | egrep '^(docker\\.io/)?${image}$'"
   }
 
   if $docker_dir {

--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -70,7 +70,7 @@ define docker::image(
   } elsif $docker_tar {
     $image_install = "${docker_command} load -i ${docker_tar}"
   } else {
-    $image_install = "${docker_command} pull ${image_arg}"
+    $image_install = "/usr/bin/update_docker_image.sh ${image_arg}"
   }
 
   if $ensure == 'absent' {
@@ -80,17 +80,21 @@ define docker::image(
       timeout => 0,
     }
   } elsif $ensure == 'latest' {
-    exec { $image_install:
+    exec { "echo 'Update of ${image_arg} complete'":
       environment => 'HOME=/root',
       path        => ['/bin', '/usr/bin'],
       timeout     => 0,
+      onlyif      => $image_install,
+      require     => File['/usr/bin/update_docker_image.sh'],
     }
-  } else {
+  } elsif $ensure == 'present' {
     exec { $image_install:
       environment => 'HOME=/root',
       path        => ['/bin', '/usr/bin'],
       unless      => $image_find,
       timeout     => 0,
+      returns     => ['0', '1']
     }
   }
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,6 +30,11 @@
 #   Defaults to undef: docker defaults to info if no value specified
 #   Valid values: debug, info, warn, error, fatal
 #
+# [*selinux_enabled*]
+#   Enable selinux support. Default is false. SELinux does  not  presently
+#   support  the  BTRFS storage driver.
+#   Valid values: true, false
+#
 # [*use_upstream_package_source*]
 #   Whether or not to use the upstream package source.
 #   If you run your own package mirror, you may set this
@@ -141,6 +146,7 @@ class docker(
   $tcp_bind                    = $docker::params::tcp_bind,
   $socket_bind                 = $docker::params::socket_bind,
   $log_level                   = $docker::params::log_level,
+  $selinux_enabled             = $docker::params::selinux_enabled,
   $use_upstream_package_source = $docker::params::use_upstream_package_source,
   $package_source_location     = $docker::params::package_source_location,
   $service_state               = $docker::params::service_state,
@@ -179,6 +185,10 @@ class docker(
 
   if $log_level {
     validate_re($log_level, '^(debug|info|warn|error|fatal)$', 'log_level must be one of debug, info, warn, error or fatal')
+  }
+
+  if $selinux_enabled {
+    validate_re($selinux_enabled, '^(true|false)$', 'selinux_enabled must be true or false')
   }
 
   if $storage_driver {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -112,4 +112,13 @@ class docker::install {
       name   => $dockerpackage,
     }
   }
+
+  # Wrapper used by docker::image to ensure images are up to date
+  file { '/usr/bin/update_docker_image.sh':
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0555',
+    source => 'puppet:///modules/docker/update_docker_image.sh',
+  }
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -100,9 +100,12 @@ class docker::params {
   # Special extra packages are required on some OSes.
   # Specifically apparmor is needed for Ubuntu:
   # https://github.com/docker/docker/issues/4734
-  $prerequired_packages = $::operatingsystem ? {
-    'Debian' => ['apt-transport-https', 'cgroupfs-mount'],
-    'Ubuntu' => ['apt-transport-https', 'cgroup-lite', 'apparmor'],
+  $prerequired_packages = $::osfamily ? {
+    'Debian' => $::operatingsystem ? {
+      'Debian' => ['apt-transport-https', 'cgroupfs-mount'],
+      'Ubuntu' => ['apt-transport-https', 'cgroup-lite', 'apparmor'],
+    },
+    'RedHat' => ['device-mapper'],
     default  => [],
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,7 @@ class docker::params {
   $tcp_bind                     = undef
   $socket_bind                  = 'unix:///var/run/docker.sock'
   $log_level                    = undef
+  $selinux_enabled              = undef
   $socket_group                 = undef
   $service_state                = running
   $service_enable               = true

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,7 +33,7 @@ class docker::params {
   $package_name_default         = 'lxc-docker'
   $service_name_default         = 'docker'
   $docker_command_default       = 'docker'
-  $docker_group                 = 'docker'
+  $docker_group_default         = 'docker'
   case $::osfamily {
     'Debian' : {
       case $::operatingsystem {
@@ -48,6 +48,7 @@ class docker::params {
           $docker_command = 'docker.io'
         }
       }
+      $docker_group = $docker_group_default
       $package_source_location     = 'https://get.docker.io/ubuntu'
       $use_upstream_package_source = true
       $detach_service_in_init = true
@@ -68,12 +69,15 @@ class docker::params {
       $docker_command = $docker_command_default
       if versioncmp($::operatingsystemrelease, '7.0') < 0 {
         $detach_service_in_init = true
+        $docker_group = $docker_group_default
       } else {
         $detach_service_in_init = false
+        $docker_group = 'dockerroot'
         include docker::systemd_reload
       }
     }
     'Archlinux' : {
+      $docker_group = $docker_group_default
       $package_source_location     = ''
       $use_upstream_package_source = false
       $package_name   = 'docker'
@@ -83,6 +87,7 @@ class docker::params {
       include docker::systemd_reload
     }
     default: {
+      $docker_group = $docker_group_default
       $package_source_location     = ''
       $use_upstream_package_source = true
       $package_name   = $package_name_default

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -104,6 +104,7 @@ class docker::params {
     'Debian' => $::operatingsystem ? {
       'Debian' => ['apt-transport-https', 'cgroupfs-mount'],
       'Ubuntu' => ['apt-transport-https', 'cgroup-lite', 'apparmor'],
+      default  => [],
     },
     'RedHat' => ['device-mapper'],
     default  => [],

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -1,6 +1,6 @@
 # == Define: docker:run
 #
-# A define which manages an upstart managed docker container
+# A define which managed docker container
 #
 define docker::run(
   $image,
@@ -96,11 +96,6 @@ define docker::run(
   $sanitised_title = regsubst($title, '[^0-9A-Za-z.\-]', '-', 'G')
   $sanitised_depends_array = regsubst($depends_array, '[^0-9A-Za-z.\-]', '-', 'G')
 
-  $provider = $::operatingsystem ? {
-    'Ubuntu' => 'upstart',
-    default  => undef,
-  }
-
   if $restart {
 
     $cidfile = "/var/run/docker-${sanitised_title}.cid"
@@ -122,18 +117,6 @@ define docker::run(
         $hasrestart = false
         $uses_systemd = false
         $mode = '0755'
-
-        # When switching between styles of init scripts (e.g. upstart and sysvinit),
-        # we want to stop the service using the old init script. Since `service` will
-        # prefer a sysvinit style script over an upstart one if both exist, we need
-        # to stop the service before adding the sysvinit script.
-        exec { "/usr/sbin/service docker-${sanitised_title} stop":
-          onlyif  => "/usr/bin/test -f ${deprecated_initscript}"
-        } ->
-        file { $deprecated_initscript:
-          ensure => absent
-        } ->
-        File[$initscript]
       }
       'RedHat': {
         if versioncmp($::operatingsystemrelease, '7.0') < 0 {
@@ -193,7 +176,6 @@ define docker::run(
       enable     => true,
       hasstatus  => $hasstatus,
       hasrestart => $hasrestart,
-      provider   => $provider,
       require    => File[$initscript],
     }
 

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -1,6 +1,27 @@
 # == Define: docker:run
 #
-# A define which managed docker container
+# A define which manages a running docker container.
+#
+# == Parameters
+#
+# [*restart*]
+# Sets a restart policy on the docker run.
+# Note: If set, puppet will NOT setup an init script to manage, instead
+# it will do a raw docker run command using a CID file to track the container 
+# ID.
+#
+# If you want a normal named container with an init script and a restart policy
+# you must use the extra_parameters feature and pass it in like this:
+#
+#    extra_parameters => ['--restart=always']
+#
+# This will allow the docker container to be restarted if it dies, without
+# puppet help.
+#
+# [*extra_parameters*]
+# An array of additional command line arguments to pass to the `docker run`
+# command. Useful for adding additional new or experimental options that the
+# module does not yet support.
 #
 define docker::run(
   $image,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -27,6 +27,7 @@ class docker::service (
   $tcp_bind             = $docker::tcp_bind,
   $socket_bind          = $docker::socket_bind,
   $log_level            = $docker::log_level,
+  $selinux_enabled      = $docker::selinux_enabled,
   $socket_group         = $docker::socket_group,
   $dns                  = $docker::dns,
   $dns_search           = $docker::dns_search,

--- a/spec/acceptance/docker_spec.rb
+++ b/spec/acceptance/docker_spec.rb
@@ -95,6 +95,21 @@ describe 'docker class' do
       its(:exit_status) { should eq 0 }
       its(:stdout) { should match /docker/ }
     end
-
   end
+
+  context "When asked to have the latest image of something" do
+    let(:pp) {"
+        class { 'docker':
+          docker_users => [ 'testuser' ]
+        }
+	docker::image { 'busybox': ensure => latest }
+    "}
+    it 'should apply with no errors' do
+      apply_manifest(pp, :catch_failures=>true)
+    end
+    it 'should be idempotent' do
+      apply_manifest(pp, :catch_changes=>true)
+    end
+  end
+
 end

--- a/spec/acceptance/docker_spec.rb
+++ b/spec/acceptance/docker_spec.rb
@@ -14,6 +14,11 @@ describe 'docker class' do
   service_name = 'docker'
   command = 'docker'
 
+  before(:all) do
+    # This is a hack to work around a dependency issue
+    shell('sudo yum install -y device-mapper') if fact('osfamily') == 'RedHat'
+  end
+
   context 'default parameters' do
     let(:pp) {"
         class { 'docker':

--- a/spec/acceptance/nodesets/centos-66-x64.yml
+++ b/spec/acceptance/nodesets/centos-66-x64.yml
@@ -9,3 +9,4 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: foss
+  color: false

--- a/spec/acceptance/nodesets/centos-70-x64.yml
+++ b/spec/acceptance/nodesets/centos-70-x64.yml
@@ -9,3 +9,4 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: foss
+  color: false

--- a/spec/acceptance/nodesets/ubuntu-server-12042-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-12042-x64.yml
@@ -10,3 +10,4 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: foss
+  color: false

--- a/spec/acceptance/nodesets/ubuntu-server-1404-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-1404-x64.yml
@@ -10,3 +10,4 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: foss
+  color: false

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -233,6 +233,20 @@ describe 'docker', :type => :class do
         end
       end
 
+      context 'with specific selinux_enabled parameter' do
+        let(:params) { { 'selinux_enabled' => 'true' } }
+        it { should contain_file(service_config_file).with_content(/--selinux-enabled=true/) }
+      end
+
+      context 'with an invalid selinux_enabled parameter' do
+        let(:params) { { 'selinux_enabled' => 'yes'} }
+        it do
+          expect {
+            should contain_package('docker')
+          }.to raise_error(Puppet::Error, /selinux_enabled must be true or false/)
+        end
+      end
+
       context 'with custom root dir' do
         let(:params) { {'root_dir' => '/mnt/docker'} }
         it { should contain_file(service_config_file).with_content(/-g \/mnt\/docker/) }

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -41,6 +41,12 @@ describe 'docker', :type => :class do
           it { should contain_package('docker') }
         end
 
+        context 'It should include default prerequired_packages' do
+          it { should contain_package('apt-transport-https').with_ensure('present') }
+          it { should contain_package('cgroup-lite').with_ensure('present') }
+          it { should contain_package('apparmor').with_ensure('present') }
+        end
+
         context 'when given a specific tmp_dir' do
           let(:params) {{ 'tmp_dir' => '/bigtmp' }}
           it { should contain_file('/etc/default/docker').with_content(/export TMPDIR="\/bigtmp"/) }
@@ -76,6 +82,10 @@ describe 'docker', :type => :class do
         context 'when given a specific tmp_dir' do
           let(:params) {{ 'tmp_dir' => '/bigtmp' }}
           it { should contain_file('/etc/sysconfig/docker').with_content(/export TMPDIR="\/bigtmp"/) }
+        end
+
+        context 'It should include default prerequired_packages' do
+          it { should contain_package('device-mapper').with_ensure('present') }
         end
 
       end

--- a/spec/defines/image_spec.rb
+++ b/spec/defines/image_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 describe 'docker::image', :type => :define do
   let(:title) { 'base' }
-  it { should contain_exec('docker pull base') }
 
   context 'with ensure => absent' do
     let(:params) { { 'ensure' => 'absent' } }
@@ -21,14 +20,13 @@ describe 'docker::image', :type => :define do
 
   context 'with ensure => present' do
     let(:params) { { 'ensure' => 'present' } }
-    it { should contain_exec('docker pull base') }
+    it { should contain_exec('/usr/bin/update_docker_image.sh base') }
   end
 
   context 'with docker_file => Dockerfile' do
     let(:params) { { 'docker_file' => 'Dockerfile' }}
     it { should contain_exec('docker build -t base - < Dockerfile') }
   end
-
 
   context 'with ensure => present and docker_file => Dockerfile' do
     let(:params) { { 'ensure' => 'present', 'docker_file' => 'Dockerfile' } }
@@ -47,7 +45,7 @@ describe 'docker::image', :type => :define do
 
   context 'with ensure => present and image_tag => precise' do
     let(:params) { { 'ensure' => 'present', 'image_tag' => 'precise' } }
-    it { should contain_exec('docker pull base:precise') }
+    it { should contain_exec('/usr/bin/update_docker_image.sh base:precise') }
   end
 
   context 'with ensure => present and image_tag => precise and docker_file => Dockerfile' do
@@ -99,19 +97,19 @@ describe 'docker::image', :type => :define do
 
   context 'with ensure => latest' do
     let(:params) { { 'ensure' => 'latest' } }
-    it { should contain_exec('docker pull base') }
+    it { should contain_exec("echo 'Update of base complete'").with_onlyif('/usr/bin/update_docker_image.sh base') }
   end
 
   context 'with ensure => latest and image_tag => precise' do
     let(:params) { { 'ensure' => 'latest', 'image_tag' => 'precise' } }
-    it { should contain_exec('docker pull base:precise') }
+    it { should contain_exec("echo 'Update of base:precise complete'") }
   end
 
   context 'with an invalid image name' do
     let(:title) { 'with spaces' }
     it do
       expect {
-        should contain_exec('docker pull with spaces')
+        should contain_exec('/usr/bin/update_docker_image.sh with spaces')
       }.to raise_error(Puppet::Error)
     end
   end

--- a/templates/etc/conf.d/docker.erb
+++ b/templates/etc/conf.d/docker.erb
@@ -8,6 +8,7 @@ other_args="<% -%>
 <% if @tcp_bind %> -H <%= @tcp_bind %><% end -%>
 <% if @socket_bind %> -H <%= @socket_bind %><% end -%>
 <% if @log_level %> -l <%= @log_level %><% end -%>
+<% if @selinux_enabled %> --selinux-enabled=<%= @selinux_enabled %><% end -%>
 <% if @socket_group %> -G <%= @socket_group %><% end -%>
 <% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end -%>
 <% if @dns_search %><% @dns_search_array.each do |domain| %> --dns-search <%= domain %><% end %><% end -%>

--- a/templates/etc/default/docker.erb
+++ b/templates/etc/default/docker.erb
@@ -23,6 +23,7 @@ DOCKER_OPTS="\
 <% if @tcp_bind %> -H <%= @tcp_bind %><% end -%>
 <% if @socket_bind %> -H <%= @socket_bind %><% end -%>
 <% if @log_level %> -l <%= @log_level %><% end -%>
+<% if @selinux_enabled %> --selinux-enabled=<%= @selinux_enabled %><% end -%>
 <% if @socket_group %> -G <%= @socket_group %><% end -%>
 <% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end -%>
 <% if @dns_search %><% @dns_search_array.each do |domain| %> --dns-search <%= domain %><% end %><% end -%>

--- a/templates/etc/sysconfig/docker.erb
+++ b/templates/etc/sysconfig/docker.erb
@@ -8,6 +8,7 @@ other_args="<% -%>
 <% if @tcp_bind %> -H <%= @tcp_bind %><% end -%>
 <% if @socket_bind %> -H <%= @socket_bind %><% end -%>
 <% if @log_level %> -l <%= @log_level %><% end -%>
+<% if @selinux_enabled %> --selinux-enabled=<%= @selinux_enabled %><% end -%>
 <% if @socket_group %> -G <%= @socket_group %><% end -%>
 <% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end -%>
 <% if @dns_search %><% @dns_search_array.each do |domain| %> --dns-search <%= domain %><% end %><% end -%>

--- a/templates/etc/sysconfig/docker.rhel7.erb
+++ b/templates/etc/sysconfig/docker.rhel7.erb
@@ -5,6 +5,7 @@ OPTIONS="<% if @root_dir %> -g <%= @root_dir %><% end -%>
 <% if @tcp_bind %> -H <%= @tcp_bind %><% end -%>
 <% if @socket_bind %> -H <%= @socket_bind %><% end -%>
 <% if @log_level %> -l <%= @log_level %><% end -%>
+<% if @selinux_enabled %> --selinux_enabled=<%= @selinux_enabled %><% end -%>
 <% if @socket_group %> -G <%= @socket_group %><% end -%>
 <% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end -%>
 <% if @dns_search %><% @dns_search_array.each do |domain| %> --dns-search <%= domain %><% end %><% end -%>


### PR DESCRIPTION
Primary: @bobtfish 

This brings us back up to upstream and adds a wrapper for docker pull to allow puppet to know when an update has been applied, so it can correctly converge and refresh other resources.

The addresses the problem of `docker::image { 'foo': ensure => latest }` never converging. And it also solves the problem of 

``` puppet
docker::image { 'foo': ensure => latest } ~>
docker::run { 'foo': }
```

never converging and always restarting the image. (which it does now with the recent init script fixes)

I intend to dogfood this at yelp for a while and then PR upstream cc @garethr 
Or if he is a true-believer, can take it based on my test coverage?
