### PR TITLE
Fix docker::run when used on systemd

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -197,7 +197,15 @@ define docker::run(
 
     service { "docker-${sanitised_title}":
       ensure     => $running,
-      enable     => true,
+      enable     => $::lsbdistcodename ? {
+        # upstart
+        lucid   => true,
+        trusty  => true,
+        # systemd can't handle enabling/disabling of /etc/init.d scripts.
+        # We could remove this if we upgraded to the latest garethr-docker (it
+        # supports systemd).
+        default => undef,
+      },
       hasstatus  => $hasstatus,
       hasrestart => $hasrestart,
       require    => File[$initscript],

--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -59,8 +59,8 @@ start() {
 
     if [ "true" = "$($docker inspect --format='{{.State.Running}}' <%= @sanitised_title %>)" ]; then
        failure
-       printf "Container <%= @sanitised_title %> is still running.\n"
-       exit 7
+       printf "Container <%= @sanitised_title %> is already running.\n"
+       exit 0
     fi
 
     printf "Starting $prog:\t"


### PR DESCRIPTION
**These patches do not block upgrading to the latest garether-docker; they can both be dropped.**

Both of these changes are only necessary because we are so far behind upstream, which already has very good support for systemd.

The change to the exit code was proposed upstream anyway as it is an overall good patch (init scripts are supposed to exit 0 when asked to start and the service is already running -- see the cited LSB spec from the issue):
https://github.com/garethr/garethr-docker/issues/626