### PR TITLE
Pass in the new data-root option for new docker versions

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -41,6 +41,7 @@ class docker::service (
   $execdriver           = $docker::execdriver,
   $storage_driver       = $docker::storage_driver,
   $tmp_dir              = $docker::tmp_dir,
+  $docker_version       = $docker::ensure,
 ) {
   $dns_array = any2array($dns)
   $dns_search_array = any2array($dns_search)

--- a/templates/etc/default/docker.erb
+++ b/templates/etc/default/docker.erb
@@ -19,7 +19,11 @@ export TMPDIR="<%= @tmp_dir %>"
 
 # # Use DOCKER_OPTS to modify the daemon startup options.
 DOCKER_OPTS="\
+<%- if scope.function_versioncmp([@docker_version, '18.03']) >= 0 -%>
+<% if @root_dir %> --data-root <%= @root_dir %><% end -%>
+<%- else -%>
 <% if @root_dir %> -g <%= @root_dir %><% end -%>
+<%- end -%>
 <% if @tcp_bind %> -H <%= @tcp_bind %><% end -%>
 <% if @socket_bind %> -H <%= @socket_bind %><% end -%>
 <% if @log_level %> -l <%= @log_level %><% end -%>


### PR DESCRIPTION
It is a little hard to reconcile with upstream, but even if we did it doesn't support versions of docker from 2018.

This is kinda the "minimal" amount of work I need to get this done so that dockerd will start. 